### PR TITLE
MCP Client & FastAPI Interface for DB Connections

### DIFF
--- a/claude_fastapi.py
+++ b/claude_fastapi.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+import asyncio
+import os
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+import json
+
+from claude_mcp_client import ClaudeMCPClient
+
+"""
+postgres-mcp postgres://<balbablba>/db --transport sse --sse-port 8000
+"""
+app = FastAPI(
+    title="Claude MCP API",
+    description="Chat with Claude using PostgreSQL database tools via MCP",
+    version="1.0.0"
+)
+
+# Global client instance
+claude_client: Optional[ClaudeMCPClient] = None
+
+
+class QuestionRequest(BaseModel):
+    question: str
+    stream: bool = False
+
+
+class QuestionResponse(BaseModel):
+    response: str
+    tools_used: list = []
+
+
+@app.on_event("startup")
+async def startup_event():
+    """Initialize Claude MCP client on startup."""
+    global claude_client
+    
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("⚠️  Warning: ANTHROPIC_API_KEY not set. Claude functionality will be disabled.")
+        return
+    
+    claude_client = ClaudeMCPClient(api_key)
+    
+    # Connect to MCP server
+    success = await claude_client.connect_to_mcp()
+    if success:
+        print(f"✅ Connected to MCP server with {len(claude_client.available_tools)} tools")
+    else:
+        print("❌ Failed to connect to MCP server")
+        claude_client = None
+
+
+@app.get("/")
+async def root():
+    """Health check endpoint."""
+    status = "connected" if claude_client else "disconnected"
+    tools_count = len(claude_client.available_tools) if claude_client else 0
+    
+    return {
+        "message": "Claude MCP API is running",
+        "status": status,
+        "tools_available": tools_count
+    }
+
+
+@app.get("/health")
+async def health_check():
+    """Detailed health check."""
+    if not claude_client:
+        raise HTTPException(status_code=503, detail="Claude client not initialized")
+    
+    return {
+        "claude_connected": True,
+        "mcp_tools": len(claude_client.available_tools),
+        "available_tools": [tool["name"] for tool in claude_client.available_tools[:5]]  # Show first 5
+    }
+
+
+@app.post("/ask", response_model=QuestionResponse)
+async def ask_claude(request: QuestionRequest):
+    """Ask Claude a question about the database."""
+    if not claude_client:
+        raise HTTPException(status_code=503, detail="Claude client not available. Check ANTHROPIC_API_KEY.")
+    
+    try:
+        response = await claude_client.ask_claude(request.question)
+        
+        return QuestionResponse(
+            response=response,
+            tools_used=[]  # Could track this if needed
+        )
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error processing question: {str(e)}")
+
+
+@app.get("/ask-stream")
+async def ask_claude_stream(question: str):
+    """Ask Claude a question and stream the response."""
+    if not claude_client:
+        raise HTTPException(status_code=503, detail="Claude client not available")
+    
+    async def generate_stream():
+        try:
+            # Send initial status
+            yield f"data: {json.dumps({'type': 'status', 'message': 'Processing question...'})}\n\n"
+            
+            # This is a simplified streaming - in a real implementation you'd 
+            # need to modify the claude_client to yield intermediate results
+            response = await claude_client.ask_claude(question)
+            
+            # Stream the final response
+            yield f"data: {json.dumps({'type': 'response', 'content': response})}\n\n"
+            yield f"data: {json.dumps({'type': 'complete'})}\n\n"
+            
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+    
+    return StreamingResponse(
+        generate_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        }
+    )
+
+
+@app.get("/tools")
+async def list_available_tools():
+    """List all available MCP tools."""
+    if not claude_client:
+        raise HTTPException(status_code=503, detail="Claude client not available")
+    
+    return {
+        "tools": claude_client.available_tools
+    }
+
+
+# Example questions endpoint for testing
+@app.get("/examples")
+async def get_example_questions():
+    """Get example questions to ask Claude."""
+    return {
+        "examples": [
+            "What schemas are available in the database?",
+            "What tables can you see? Show me tables from all user schemas.",
+            "How many patients are in the database?",
+            "What are the most recent 5 tasks?",
+            "Show me the structure of the Patient table",
+            "What forms are available in the system?",
+            "How many SMS campaigns are there?",
+            "What providers are in the system?"
+        ]
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    
+    print("🚀 Starting Claude MCP FastAPI server...")
+    print("📋 Available endpoints:")
+    print("  - GET  / - Health check")
+    print("  - POST /ask - Ask Claude a question")
+    print("  - GET  /ask-stream?question=... - Stream Claude's response")
+    print("  - GET  /tools - List available MCP tools")
+    print("  - GET  /examples - Get example questions")
+    print("  - GET  /docs - FastAPI documentation")
+    print("\n💡 Make sure to set ANTHROPIC_API_KEY environment variable!")
+    print("💡 Make sure MCP server is running on port 8000!")
+    
+    uvicorn.run(
+        "claude_fastapi:app",
+        host="localhost",
+        port=8003,
+        reload=True
+    )

--- a/claude_mcp_client.py
+++ b/claude_mcp_client.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+
+import asyncio
+import json
+import os
+from typing import Any, Dict, List
+
+from mcp.client.sse import sse_client
+from mcp import ClientSession
+import anthropic
+
+
+class ClaudeMCPClient:
+    def __init__(self, anthropic_api_key: str):
+        self.anthropic_client = anthropic.Anthropic(
+            api_key=anthropic_api_key
+        )
+        self.mcp_session = None
+        self.available_tools = []
+        self.sql_tool_name = None
+        
+    async def connect_to_mcp(self):
+        """Connect to the MCP server and get available tools."""
+        try:
+            print("🔗 Connecting to MCP server...")
+            
+            # Note: In a real implementation, you'd want to maintain this connection
+            # For now, we'll create it fresh each time we need it
+            async with sse_client("http://localhost:8000/sse") as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    tools = await session.list_tools()
+                    
+                    self.available_tools = []
+                    for tool in tools.tools:
+                        self.available_tools.append({
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            }
+                        })
+                        
+                        # Find the SQL execution tool
+                        if "execute_sql" in tool.name:
+                            self.sql_tool_name = tool.name
+                    
+                    print(f"✅ Connected to MCP! Found {len(self.available_tools)} tools")
+                    return True
+                    
+        except Exception as e:
+            print(f"❌ Failed to connect to MCP: {e}")
+            return False
+    
+    async def execute_mcp_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Execute a tool via MCP and return the result as a string."""
+        try:
+            async with sse_client("http://localhost:8000/sse") as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool_name, arguments)
+                    
+                    # Extract text content from the result
+                    if result.content:
+                        return "\n".join([
+                            content.text for content in result.content 
+                            if hasattr(content, 'text')
+                        ])
+                    else:
+                        return "No results returned"
+                        
+        except Exception as e:
+            return f"Error executing tool: {e}"
+    
+    def create_claude_tools(self) -> List[Dict]:
+        """Convert MCP tools to Claude API tool format."""
+        claude_tools = []
+        
+        for tool in self.available_tools:
+            if "execute_sql" in tool["name"]:
+                claude_tools.append({
+                    "name": "execute_sql",
+                    "description": "Execute SQL queries against the PostgreSQL database",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "sql": {
+                                "type": "string",
+                                "description": "The SQL query to execute"
+                            }
+                        },
+                        "required": ["sql"]
+                    }
+                })
+            elif "list_schemas" in tool["name"]:
+                claude_tools.append({
+                    "name": "list_schemas",
+                    "description": "List all database schemas",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {},
+                        "required": []
+                    }
+                })
+            elif "list_objects" in tool["name"]:
+                claude_tools.append({
+                    "name": "list_objects",
+                    "description": "List database objects (tables, views, etc.) in a schema",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "schema_name": {
+                                "type": "string",
+                                "description": "Name of the schema"
+                            },
+                            "object_type": {
+                                "type": "string",
+                                "description": "Type of object: table, view, sequence, or extension",
+                                "default": "table"
+                            }
+                        },
+                        "required": ["schema_name"]
+                    }
+                })
+        
+        return claude_tools
+    
+    async def ask_claude(self, question: str) -> str:
+        """Ask Claude a question with access to MCP tools."""
+        
+        # First, ensure we're connected to MCP
+        if not self.available_tools:
+            await self.connect_to_mcp()
+        
+        claude_tools = self.create_claude_tools()
+        
+        messages = [
+            {
+                "role": "user",
+                "content": question
+            }
+        ]
+        
+        try:
+            # Continue conversation until Claude stops making tool calls
+            max_iterations = 10  # Prevent infinite loops
+            iteration = 0
+            
+            while iteration < max_iterations:
+                iteration += 1
+                print(f"🔄 Conversation iteration {iteration}")
+                
+                response = self.anthropic_client.messages.create(
+                    model="claude-3-5-sonnet-20241022",
+                    messages=messages,
+                    tools=claude_tools if claude_tools else None,
+                    max_tokens=4000
+                )
+                
+                # Check if Claude wants to use tools
+                tool_use_blocks = [block for block in response.content if block.type == "tool_use"]
+                
+                if tool_use_blocks:
+                    # Execute all requested tools
+                    tool_results = []
+                    
+                    for block in tool_use_blocks:
+                        tool_name = block.name
+                        arguments = block.input
+                        
+                        print(f"🔧 Claude is calling tool: {tool_name}")
+                        print(f"📝 Arguments: {arguments}")
+                        
+                        # Map Claude tool names to MCP tool names
+                        mcp_tool_name = None
+                        for mcp_tool in self.available_tools:
+                            if tool_name in mcp_tool["name"] or mcp_tool["name"].endswith(f"_{tool_name}"):
+                                mcp_tool_name = mcp_tool["name"]
+                                break
+                        
+                        if mcp_tool_name:
+                            result = await self.execute_mcp_tool(mcp_tool_name, arguments)
+                            print(f"📊 Tool result: {result[:200]}...")
+                            
+                            tool_results.append({
+                                "type": "tool_result",
+                                "tool_use_id": block.id,
+                                "content": result
+                            })
+                        else:
+                            tool_results.append({
+                                "type": "tool_result", 
+                                "tool_use_id": block.id,
+                                "content": f"Error: Tool {tool_name} not found"
+                            })
+                    
+                    # Add assistant response and tool results to conversation
+                    messages.append({
+                        "role": "assistant", 
+                        "content": response.content
+                    })
+                    messages.append({
+                        "role": "user",
+                        "content": tool_results
+                    })
+                    
+                    # Continue the loop to let Claude process the results and potentially make more tool calls
+                    
+                else:
+                    # No more tool calls, Claude has finished
+                    return response.content[0].text if response.content else "No response"
+            
+            # If we hit max iterations, return the last response
+            return "Response truncated due to maximum iteration limit"
+            
+        except Exception as e:
+            return f"Error calling Claude API: {e}"
+
+
+async def main():
+    """Interactive chat with Claude using MCP tools."""
+    
+    # Get Anthropic API key
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("❌ Please set ANTHROPIC_API_KEY environment variable")
+        return
+    
+    client = ClaudeMCPClient(api_key)
+    
+    # Connect to MCP
+    if not await client.connect_to_mcp():
+        print("❌ Failed to connect to MCP server. Make sure it's running on port 8000.")
+        return
+    
+    print("\n🤖 Claude MCP Client Ready!")
+    print("You can now ask Claude questions about your database.")
+    print("Type 'quit' to exit.\n")
+    
+    while True:
+        question = input("You: ").strip()
+        
+        if question.lower() in ['quit', 'exit', 'q']:
+            print("👋 Goodbye!")
+            break
+        
+        if not question:
+            continue
+        
+        print("🤔 Claude is thinking...")
+        response = await client.ask_claude(question)
+        print(f"\n🤖 Claude: {response}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/claude_mcp_client.py
+++ b/claude_mcp_client.py
@@ -155,6 +155,7 @@ class ClaudeMCPClient:
                 response = self.anthropic_client.messages.create(
                     model="claude-3-5-sonnet-20241022",
                     messages=messages,
+
                     tools=claude_tools if claude_tools else None,
                     max_tokens=4000
                 )

--- a/client_requirements.txt
+++ b/client_requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+httpx>=0.25.0
+pydantic>=2.4.0


### PR DESCRIPTION
This presents a way to have a fastapi serve a mcp client that hooks up to postgres.

To test this you'd start the mcp server with

`postgres-mcp postgres://<balbablba>/db --transport sse --sse-port 8000`

Then you'd start the fastapi instance with

`python claude_fastapi.py`

you could then hit the /query endpoint and it would execute different tools until it hits the max tool iteration of 10. That value can be configurable but this is just an example of setting up an mcp connection in code with SSE interaction rather than stdio which is what Claude Desktop uses.

We could technically build out a front end on milkyway to get the outputs of this. If there was an easy way to hook up a stream to the endpoint api then that would be better so we wouldnt need to wait a long time for the answer to come back after multiple tool iterations. But yeah, poc for now